### PR TITLE
Add Crunchbase to data catalog

### DIFF
--- a/conf/base/catalog.yml
+++ b/conf/base/catalog.yml
@@ -124,3 +124,76 @@ nih.data_processing.clinical_trials_with_references.intermediate:
 nih.data_processing.clinical_trials_links_to_papers.intermediate:
   <<: *_csv
   filepath: s3://alphafold-impact/data/02_intermediate/nih/clinical_trials/clinical_trials_links_to_papers.csv
+
+# Crunchbase data
+_cb_raw: &_cb_raw
+  type: pandas.CSVDataset
+  credentials: nesta_s3_credentials
+
+cb.data_processing.acquisitions.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/acquisitions.csv
+
+cb.data_processing.category_groups.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/category_groups.csv
+
+cb.data_processing.degrees.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/degrees.csv
+
+cb.data_processing.event_appearances.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/event_appearances.csv
+
+cb.data_processing.events.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/events.csv
+
+cb.data_processing.funding_rounds.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/funding_rounds.csv
+
+cb.data_processing.funds.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/funds.csv
+
+cb.data_processing.investment_partners.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/investment_partners.csv
+
+cb.data_processing.investments.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/investments.csv
+  
+cb.data_processing.investors.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/investors.csv
+  
+cb.data_processing.ipos.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/ipos.csv
+  
+cb.data_processing.jobs.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/jobs.csv
+  
+cb.data_processing.org_parents.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/org_parents.csv
+  
+cb.data_processing.organization_descriptions.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/organization_descriptions.csv
+  
+cb.data_processing.organizations.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/organizations.csv
+  
+cb.data_processing.people_descriptions.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/people_descriptions.csv
+  
+cb.data_processing.people.raw:
+  <<: *_cb_raw
+  filepath: ${diss.crunchbase}/people.csv

--- a/conf/base/catalog_globals.yml
+++ b/conf/base/catalog_globals.yml
@@ -1,2 +1,5 @@
 _json:
   type: json.JSONDataset
+
+diss:
+  crunchbase: s3://discovery-iss/data/crunchbase/Crunchbase_20240109_000941


### PR DESCRIPTION
This is a simple addition that puts Crunchbase datasets in to the data catalog. The crunchbase datasets are for:

- acquisitions
- category_groups
- degrees
- event_appearances
- events
- funding_rounds
- funds
- investment_partners
- investments
- investors
- ipos
- jobs
- org_parents
- organization_descriptions
- organizations
- people_descriptions
- people

---

**For reviewer**

Notes:

- To load the data, you will need Nesta AWS credentials set as `nesta_s3_credentials` in `conf/local/credentials.yml`

Questions and requests:

- Can this be consolidated further through smarter use of yaml in a kedro friendly way?