### PR TITLE
[27] Update OpenAlex works for concepts pipeline to new naming conventions

### DIFF
--- a/conf/base/catalog.yml
+++ b/conf/base/catalog.yml
@@ -52,6 +52,10 @@ oa.data_collection.downstream.cites.intermediate:
   <<: *_js_ptd
   path: "s3://alphafold-impact/data/02_intermediate/oa/works/downstream/${globals:oa.data_collection.get.work_id}/"
 
+oa.data_collection.works_for_concepts.raw:
+  <<: *_pq
+  filepath: s3://alphafold-impact/data/01_raw/oa/works/oa_works_for_concepts.parquet
+
 # Raw Gateway to Research data - includes projects, publications, organisations and funds 
 
 "{source}.data_collection.{label}.raw":
@@ -105,7 +109,6 @@ oa.data_processing.gtr.citations.alphafold:
   filepath: s3://alphafold-impact/data/03_primary/gtr/outcomes/publications/oa/citations.parquet
 
 # Openalex works - Concepts
-
 oa_raw_works_for_concepts_and_years:
   type: kedro_datasets.pandas.JSONDataset
   filepath: s3://alphafold-impact/data/01_raw/openalex/works/oa_works_for_concepts_and_years.json

--- a/conf/base/parameters.yml
+++ b/conf/base/parameters.yml
@@ -32,6 +32,15 @@ oa:
       api: *api
       get: *get
       filter: cites
+    
+    # Works for concepts
+    works_for_concepts:
+      test_concept_ids:
+        - "c10010492" # Protein sequencing
+        - "c204328495" # Protein folding
+      test_publication_years:
+        - 2022
+        - 2023
 
     # Additional settings
     config: &config
@@ -47,14 +56,6 @@ oa:
       config: *config
       filter_doi: doi
       filter_oa: "ids.openalex"
-
-test_concept_ids:
-  - "c10010492" # Protein sequencing
-  - "c204328495" # Protein folding
-
-test_publication_years:
-  - 2022
-  - 2023
 
 # Gateway to Research (gtr) configuration
 gtr:

--- a/src/alphafold_impact/pipelines/data_collection_oa/pipeline.py
+++ b/src/alphafold_impact/pipelines/data_collection_oa/pipeline.py
@@ -35,7 +35,7 @@ from .nodes import (
     load_referenced_work_ids,
     retrieve_oa_works_for_concepts_and_years,
     fetch_citation_depth,
-    create_network_graph
+    create_network_graph,
 )
 
 
@@ -97,10 +97,11 @@ def create_pipeline(**kwargs) -> Pipeline:  # pylint: disable=C0116,W0613
                     "params:test_concept_ids",
                     "params:test_publication_years",
                 ],
-                outputs="oa_raw_works_for_concepts_and_years",
+                outputs="raw",
             ),
         ],
-        tags="works_for_concepts_and_years",
+        namespace="oa.data_collection.works_for_concepts",
+        tags="works_for_concepts",
     )
 
     gtr_collection_pipeline = pipeline(


### PR DESCRIPTION
Closes #27 

This PR updates the OpenAlex works for concepts pipeline by:
* Using new naming scheme in the data catalog and storing data as parquet file
* Using new structure in the parameters file
* Moving `chunk_list` function into utils
* Updating module docstrings in `data_collection_oa/utils.py` and `data_collection_oa/nodes.py`