### PR TITLE
[31] Link NIH clinical trials to OpenAlex papers

### DIFF
--- a/conf/base/catalog.yml
+++ b/conf/base/catalog.yml
@@ -113,10 +113,10 @@ nih.data_collection.clinical_trials.raw:
   <<: *_csv_ptd
   path: s3://alphafold-impact/data/01_raw/nih/clinical_trials/
 
-nih.processing.clinical_trials_with_references.intermediate:
+nih.data_processing.clinical_trials_with_references.intermediate:
   <<: *_csv
   filepath: s3://alphafold-impact/data/02_intermediate/nih/clinical_trials/clinical_trials_with_references.csv
 
-nih.processing.clinical_trials_links_to_papers.intermediate:
+nih.data_processing.clinical_trials_links_to_papers.intermediate:
   <<: *_csv
   filepath: s3://alphafold-impact/data/02_intermediate/nih/clinical_trials/clinical_trials_links_to_papers.csv

--- a/conf/base/catalog.yml
+++ b/conf/base/catalog.yml
@@ -8,6 +8,10 @@ _pq: &_pq
   load_args:
     engine: pyarrow
 
+_csv: &_csv
+  type: pandas.CSVDataset
+  credentials: s3_credentials
+
 _js_ptd: &_js_ptd
   type: partitions.PartitionedDataset
   dataset: ${_json.type}
@@ -108,3 +112,7 @@ works_for_concepts:
 nih.data_collection.clinical_trials.raw:
   <<: *_csv_ptd
   path: s3://alphafold-impact/data/01_raw/nih/clinical_trials/
+
+nih.processing.clinical_trials_with_references.intermediate:
+  <<: *_csv
+  filepath: s3://alphafold-impact/data/02_intermediate/nih/clinical_trials/clinical_trials_with_references.csv

--- a/conf/base/catalog.yml
+++ b/conf/base/catalog.yml
@@ -116,3 +116,7 @@ nih.data_collection.clinical_trials.raw:
 nih.processing.clinical_trials_with_references.intermediate:
   <<: *_csv
   filepath: s3://alphafold-impact/data/02_intermediate/nih/clinical_trials/clinical_trials_with_references.csv
+
+nih.processing.clinical_trials_links_to_papers.intermediate:
+  <<: *_csv
+  filepath: s3://alphafold-impact/data/02_intermediate/nih/clinical_trials/clinical_trials_links_to_papers.csv

--- a/src/alphafold_impact/pipelines/data_collection_nih_clinical_trials/pipeline.py
+++ b/src/alphafold_impact/pipelines/data_collection_nih_clinical_trials/pipeline.py
@@ -3,7 +3,7 @@
 This pipeline fetches NIH clinical trials data.
 To run this pipeline, use the following command:
 
-    $ kedro run --pipeline data_collection_gtr
+    $ kedro run --pipeline data_collection_nih_clinical_trials
 """
 from kedro.pipeline import Pipeline, pipeline, node
 from .nodes import collect_and_save_nih_clinical_trials

--- a/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/README.md
+++ b/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/README.md
@@ -1,0 +1,25 @@
+# NIH Clinical Trials Data Processing Pipeline (`data_processing_nih_clinical_trials`)
+
+## Overview
+The `data_processing_nih_clinical_trials` pipeline processes raw data fetched from `clinicaltrials.gov`. This pipeline focuses on transforming the raw data into format suitable for further analysis within the project.
+
+## Modules
+### `nodes.py`
+This module contains the core functionalities for the pipeline:
+- `trials_with_references`: Loads NIH clinical trials from partitioned dataset, filters out trials that do not reference a paper, concatenates results into one DataFrame.
+- `trials_links_to_papers`: Produces a DataFrame which can be used to link NIH clinical trials to research papers via PubMed ID or DOI.
+
+
+### `pipeline.py`
+Defines the `data_processing_nih_clinical_trials` pipeline.
+
+## Usage
+To execute the entire `data_processing_nih_clinical_trials` pipeline, run:
+```bash
+$ kedro run --pipeline data_processing_nih_clinical_trials
+```
+
+For running specific parts of the pipeline, such as a single data type, use the `--tags` flag. For example:
+```bash
+$ kedro run --pipeline data_processing_nih_clinical_trials --tags trials_links_to_papers
+```

--- a/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/README.md
+++ b/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/README.md
@@ -7,7 +7,7 @@ The `data_processing_nih_clinical_trials` pipeline processes raw data fetched fr
 ### `nodes.py`
 This module contains the core functionalities for the pipeline:
 - `trials_with_references`: Loads NIH clinical trials from partitioned dataset, filters out trials that do not reference a paper, concatenates results into one DataFrame.
-- `trials_links_to_papers`: Produces a DataFrame which can be used to link NIH clinical trials to research papers via PubMed ID or DOI.
+- `trials_links_to_papers`: Produces a DataFrame which can be used to link NIH clinical trials to research papers via PubMed ID or DOI. This function's expected input is the output from trials_with_references.
 
 
 ### `pipeline.py`

--- a/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/__init__.py
+++ b/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/__init__.py
@@ -1,0 +1,10 @@
+"""
+This is a boilerplate pipeline 'data_processing_nih_clinical_trials'
+generated using Kedro 0.19.1
+"""
+
+from .pipeline import create_pipeline
+
+__all__ = ["create_pipeline"]
+
+__version__ = "0.1"

--- a/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/nodes.py
+++ b/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/nodes.py
@@ -33,7 +33,7 @@ def trials_with_references(
         sorted(nih_clinical_trials_partitions.items()), start=1
     ):
         ct_partition_data_with_refs = ct_partition_load_func().query(
-            "`DerivedSection.ConditionBrowseModule.ConditionMeshList.ConditionMesh`.notna()"
+            "`ProtocolSection.ReferencesModule.ReferenceList.Reference`.notna()"
         )
 
         ct_with_refs_combined = pd.concat(

--- a/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/nodes.py
+++ b/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/nodes.py
@@ -107,9 +107,9 @@ def trials_links_to_papers(
 
     This function takes a DataFrame containing clinical trial data with references
     to papers and performs the following data processing steps:
-    1. Creates new columns for each component of the paper reference.
-    2. Creates new column for the DOI.
-    3. Renames and reorders columns.
+        1. Creates new columns for each component of the paper reference.
+        2. Creates new column for the DOI.
+        3. Renames and reorders columns.
 
     Args:
         clinical_trials_with_references (pd.DataFrame): A DataFrame containing

--- a/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/nodes.py
+++ b/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/nodes.py
@@ -1,0 +1,51 @@
+"""
+This module contains the functions used in the data processing pipeline for
+the NIH clinical trials data.
+
+Functions:
+    trials_with_references: Loads NIH clinical trials from partitioned
+        dataset, filter out trials that do not reference a paper,
+        concatenate results into one DataFrame.
+"""
+from typing import Dict, Callable, Any
+import logging
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def trials_with_references(
+    nih_clinical_trials_partitions: Dict[str, Callable[[], Any]]
+) -> pd.DataFrame:
+    """Loads NIH clinical trials from partitioned dataset, filter out trials
+    that do not reference a paper, concatenate results into one DataFrame.
+
+    Args:
+        nih_clinical_trials_partitions (dict): Partitioned dataset of NIH clinical trials.
+
+    Returns:
+        DataFrame of NIH clinical trials with a paper reference.
+    """
+    ct_with_refs_combined = pd.DataFrame()
+    n_partitions = len(nih_clinical_trials_partitions)
+
+    for idx, (_, ct_partition_load_func) in enumerate(
+        sorted(nih_clinical_trials_partitions.items()), start=1
+    ):
+        ct_partition_data_with_refs = ct_partition_load_func().query(
+            "`DerivedSection.ConditionBrowseModule.ConditionMeshList.ConditionMesh`.notna()"
+        )
+
+        ct_with_refs_combined = pd.concat(
+            [ct_with_refs_combined, ct_partition_data_with_refs],
+            ignore_index=True,
+            join="outer",
+        )
+
+        logger.info(
+            "Concatenated clinical trials with references from partition %s/%s",
+            idx,
+            n_partitions,
+        )
+
+    return ct_with_refs_combined

--- a/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/nodes.py
+++ b/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/nodes.py
@@ -6,10 +6,16 @@ Functions:
     trials_with_references: Loads NIH clinical trials from partitioned
         dataset, filter out trials that do not reference a paper,
         concatenate results into one DataFrame.
+    nih_clinical_trials_links_to_papers: Produced a DataFrame which can
+        be used to link NIH clinical trials to research papers via 
+        PubMed ID or DOI.
 """
 from typing import Dict, Callable, Any
 import logging
+import ast
+import re
 import pandas as pd
+
 
 logger = logging.getLogger(__name__)
 
@@ -49,3 +55,93 @@ def trials_with_references(
         )
 
     return ct_with_refs_combined
+
+
+def _reference_string_to_df(row: pd.Series) -> pd.DataFrame:
+    """
+    Processes a row of the DataFrame, converting the reference string to a list of dictionaries.
+    Returns a DataFrame where each dictionary becomes a row, and each key in the dictionaries becomes a column.
+
+    Args:
+        row (pd.Series): A row of the DataFrame.
+
+    Returns:
+        pd.DataFrame: A DataFrame where each row corresponds to a dictionary in the reference list.
+    """
+    return pd.DataFrame(
+        ast.literal_eval(
+            row["ProtocolSection.ReferencesModule.ReferenceList.Reference"]
+        )
+    ).assign(nct_id=row["ProtocolSection.IdentificationModule.NCTId"])
+
+
+def _extract_doi(citation: str) -> str:
+    """
+    Extracts the DOI from a citation string, ensuring not to include a trailing period.
+
+    Args:
+        citation (str): The citation string from which to extract the DOI.
+
+    Returns:
+        str: The extracted DOI, or an empty string if no DOI is found.
+    """
+    # This pattern looks for 'doi: ' followed by a sequence of characters
+    doi_pattern = r"doi: ([\S]+)"
+    if not (match := re.search(doi_pattern, citation)):
+        return ""
+    doi = match[1]
+    # Remove the trailing period if it's the last character
+    if doi.endswith("."):
+        doi = doi[:-1]
+    return doi
+
+
+def trials_links_to_papers(
+    clinical_trials_with_references: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Processes clinical trial data with references to papers, to produce a DataFrame
+    which can be used to link NIH clinical trials to research papers via PubMed ID
+    or DOI.
+
+    This function takes a DataFrame containing clinical trial data with references
+    to papers and performs the following data processing steps:
+    1. Creates new columns for each component of the paper reference.
+    2. Creates new column for the DOI.
+    3. Renames and reorders columns.
+
+    Args:
+        clinical_trials_with_references (pd.DataFrame): A DataFrame containing
+            clinical trial data with references to papers.
+
+    Returns:
+        pd.DataFrame: A processed DataFrame containing the following columns:
+            - 'nct_id': The NCT ID of the clinical trial.
+            - 'ref_pmid': The PMID (PubMed ID) of the paper reference.
+            - 'ref_doi': The DOI (Digital Object Identifier) of the paper reference.
+            - 'ref_citation': The citation of the paper reference.
+            - 'ref_type': The type of the paper reference.
+            - 'ref_retraction_list': The retraction list associated with the paper reference.
+    """
+    return (
+        clinical_trials_with_references.apply(_reference_string_to_df, axis=1)
+        .pipe(lambda x: pd.concat(x.tolist(), ignore_index=True))
+        .assign(ref_doi=lambda x: x["ReferenceCitation"].apply(_extract_doi))
+        .rename(
+            columns={
+                "ReferencePMID": "ref_pmid",
+                "ReferenceType": "ref_type",
+                "ReferenceCitation": "ref_citation",
+                "RetractionList": "ref_retraction_list",
+            }
+        )[
+            [
+                "nct_id",
+                "ref_pmid",
+                "ref_doi",
+                "ref_citation",
+                "ref_type",
+                "ref_retraction_list",
+            ]
+        ]
+    )

--- a/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/nodes.py
+++ b/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/nodes.py
@@ -21,43 +21,6 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
-def trials_with_references(
-    nih_clinical_trials_partitions: Dict[str, Callable[[], Any]]
-) -> pd.DataFrame:
-    """Loads NIH clinical trials from partitioned dataset, filters out trials
-    that do not reference a paper, concatenates results into one DataFrame.
-
-    Args:
-        nih_clinical_trials_partitions (dict): Partitioned dataset of NIH clinical trials.
-
-    Returns:
-        DataFrame of NIH clinical trials with a paper reference.
-    """
-    ct_with_refs_combined = pd.DataFrame()
-    n_partitions = len(nih_clinical_trials_partitions)
-
-    for idx, (_, ct_partition_load_func) in enumerate(
-        sorted(nih_clinical_trials_partitions.items()), start=1
-    ):
-        ct_partition_data_with_refs = ct_partition_load_func().query(
-            "`ProtocolSection.ReferencesModule.ReferenceList.Reference`.notna()"
-        )
-
-        ct_with_refs_combined = pd.concat(
-            [ct_with_refs_combined, ct_partition_data_with_refs],
-            ignore_index=True,
-            join="outer",
-        )
-
-        logger.info(
-            "Concatenated clinical trials with references from partition %s/%s",
-            idx,
-            n_partitions,
-        )
-
-    return ct_with_refs_combined
-
-
 def _reference_string_to_df(row: pd.Series) -> pd.DataFrame:
     """
     Processes a row of the DataFrame, converting the reference string to a list of dictionaries.
@@ -95,6 +58,43 @@ def _extract_doi(citation: str) -> str:
     if doi.endswith("."):
         doi = doi[:-1]
     return doi
+
+
+def trials_with_references(
+    nih_clinical_trials_partitions: Dict[str, Callable[[], Any]]
+) -> pd.DataFrame:
+    """Loads NIH clinical trials from partitioned dataset, filters out trials
+    that do not reference a paper, concatenates results into one DataFrame.
+
+    Args:
+        nih_clinical_trials_partitions (dict): Partitioned dataset of NIH clinical trials.
+
+    Returns:
+        DataFrame of NIH clinical trials with a paper reference.
+    """
+    ct_with_refs_combined = pd.DataFrame()
+    n_partitions = len(nih_clinical_trials_partitions)
+
+    for idx, (_, ct_partition_load_func) in enumerate(
+        sorted(nih_clinical_trials_partitions.items()), start=1
+    ):
+        ct_partition_data_with_refs = ct_partition_load_func().query(
+            "`ProtocolSection.ReferencesModule.ReferenceList.Reference`.notna()"
+        )
+
+        ct_with_refs_combined = pd.concat(
+            [ct_with_refs_combined, ct_partition_data_with_refs],
+            ignore_index=True,
+            join="outer",
+        )
+
+        logger.info(
+            "Concatenated clinical trials with references from partition %s/%s",
+            idx,
+            n_partitions,
+        )
+
+    return ct_with_refs_combined
 
 
 def trials_links_to_papers(

--- a/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/nodes.py
+++ b/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/nodes.py
@@ -4,9 +4,9 @@ the NIH clinical trials data.
 
 Functions:
     trials_with_references: Loads NIH clinical trials from partitioned
-        dataset, filter out trials that do not reference a paper,
-        concatenate results into one DataFrame.
-    nih_clinical_trials_links_to_papers: Produced a DataFrame which can
+        dataset, filters out trials that do not reference a paper,
+        concatenates results into one DataFrame.
+    nih_clinical_trials_links_to_papers: Produces a DataFrame which can
         be used to link NIH clinical trials to research papers via 
         PubMed ID or DOI.
 """
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 def trials_with_references(
     nih_clinical_trials_partitions: Dict[str, Callable[[], Any]]
 ) -> pd.DataFrame:
-    """Loads NIH clinical trials from partitioned dataset, filter out trials
-    that do not reference a paper, concatenate results into one DataFrame.
+    """Loads NIH clinical trials from partitioned dataset, filters out trials
+    that do not reference a paper, concatenates results into one DataFrame.
 
     Args:
         nih_clinical_trials_partitions (dict): Partitioned dataset of NIH clinical trials.

--- a/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/nodes.py
+++ b/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/nodes.py
@@ -6,9 +6,10 @@ Functions:
     trials_with_references: Loads NIH clinical trials from partitioned
         dataset, filters out trials that do not reference a paper,
         concatenates results into one DataFrame.
-    nih_clinical_trials_links_to_papers: Produces a DataFrame which can
+    trials_links_to_papers: Produces a DataFrame which can
         be used to link NIH clinical trials to research papers via 
-        PubMed ID or DOI.
+        PubMed ID or DOI. This function's expected input is the
+        output from trials_with_references.
 """
 from typing import Dict, Callable, Any
 import logging

--- a/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/pipeline.py
+++ b/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/pipeline.py
@@ -1,0 +1,21 @@
+"""Pipeline for data processing.
+
+This pipeline processes NIH clinical trials data.
+To run this pipeline, use the following command:
+
+    $ kedro run --pipeline data_processing_nih_clinical_trials
+"""
+from kedro.pipeline import Pipeline, pipeline, node
+from .nodes import trials_with_references
+
+
+def create_pipeline(**kwargs) -> Pipeline:
+    return pipeline(
+        [
+            node(
+                func=trials_with_references,
+                inputs="nih.data_collection.clinical_trials.raw",
+                outputs="nih.processing.clinical_trials_with_references.intermediate",
+            ),
+        ],
+    )

--- a/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/pipeline.py
+++ b/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/pipeline.py
@@ -6,7 +6,7 @@ To run this pipeline, use the following command:
     $ kedro run --pipeline data_processing_nih_clinical_trials
 """
 from kedro.pipeline import Pipeline, pipeline, node
-from .nodes import trials_with_references
+from .nodes import trials_with_references, trials_links_to_papers
 
 
 def create_pipeline(**kwargs) -> Pipeline:
@@ -16,6 +16,13 @@ def create_pipeline(**kwargs) -> Pipeline:
                 func=trials_with_references,
                 inputs="nih.data_collection.clinical_trials.raw",
                 outputs="nih.processing.clinical_trials_with_references.intermediate",
+                tags="trials_with_references",
+            ),
+            node(
+                func=trials_links_to_papers,
+                inputs="nih.processing.clinical_trials_with_references.intermediate",
+                outputs="nih.processing.clinical_trials_links_to_papers.intermediate",
+                tags="trials_links_to_papers",
             ),
         ],
     )

--- a/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/pipeline.py
+++ b/src/alphafold_impact/pipelines/data_processing_nih_clinical_trials/pipeline.py
@@ -15,13 +15,13 @@ def create_pipeline(**kwargs) -> Pipeline:
             node(
                 func=trials_with_references,
                 inputs="nih.data_collection.clinical_trials.raw",
-                outputs="nih.processing.clinical_trials_with_references.intermediate",
+                outputs="nih.data_processing.clinical_trials_with_references.intermediate",
                 tags="trials_with_references",
             ),
             node(
                 func=trials_links_to_papers,
-                inputs="nih.processing.clinical_trials_with_references.intermediate",
-                outputs="nih.processing.clinical_trials_links_to_papers.intermediate",
+                inputs="nih.data_processing.clinical_trials_with_references.intermediate",
+                outputs="nih.data_processing.clinical_trials_links_to_papers.intermediate",
                 tags="trials_links_to_papers",
             ),
         ],


### PR DESCRIPTION
Closes #31.

This PR adds:
* Pipeline to select trials with paper references and save as the intermediate dataset: `nih.data_processing.clinical_trials_with_references.intermediate`
* Pipeline to process the reference information into a format that can be used to link papers to clinical trials and save as the intermediate dataset: `nih.data_processing.clinical_trials_links_to_papers.intermediate`