### PR TITLE
[36] Add data collection pipelines for NIH funding calls and awards

### DIFF
--- a/conf/base/catalog.yml
+++ b/conf/base/catalog.yml
@@ -117,7 +117,7 @@ lens.data_collection.{jurisdiction}.{year}.{month}.raw:
   <<: *_js_ptd
   path: s3://alphafold-impact/data/01_raw/lens/{jurisdiction}/{year}/{month}/# NIH - Clinical Trials
 
-# Nih data
+# NIH data
 nih.data_collection.clinical_trials.raw:
   <<: *_csv_ptd
   path: s3://alphafold-impact/data/01_raw/nih/clinical_trials/
@@ -129,6 +129,14 @@ nih.data_processing.clinical_trials_with_references.intermediate:
 nih.data_processing.clinical_trials_links_to_papers.intermediate:
   <<: *_csv
   filepath: s3://alphafold-impact/data/02_intermediate/nih/clinical_trials/clinical_trials_links_to_papers.csv
+
+nih.data_collection.funded_projects.raw:
+  <<: *_csv_ptd
+  path: s3://alphafold-impact/data/01_raw/nih/funded_projects/
+
+nih.data_collection.funding_opportunities.raw:
+  <<: *_csv
+  filepath: s3://alphafold-impact/data/01_raw/nih/funding_opportunities/funding_opportunities.csv
 
 # OA depth data
 oa.data_collection.depth.works:
@@ -225,3 +233,4 @@ cb.data_processing.people.raw:
 "nsf.data_collection.awards.{year}.intermediate":
   <<: *_js_ptd
   path: s3://alphafold-impact/data/02_intermediate/nsf/awards/{year}/
+

--- a/conf/base/parameters.yml
+++ b/conf/base/parameters.yml
@@ -93,6 +93,19 @@ nih:
       download_url: https://classic.clinicaltrials.gov/AllAPIJSON.zip
       zip_save_path: data/00_tmp/nih_ct.zip
       extract_path: data/01_raw/nih/clinical_trials/
+    funded_projects:
+      api_url: 'https://api.reporter.nih.gov/v2/projects/search'
+      years:
+        - 2018
+        - 2019
+        - 2020 
+        - 2021
+        - 2022
+        - 2023
+        - 2024
+    funding_opportunities:
+      api_url: 'https://search.grants.nih.gov/guide/api/data'
+      end_date: '10022024'
 
 lens:
   data_collection:

--- a/src/alphafold_impact/pipelines/data_collection_nih_funded_projects/README.md
+++ b/src/alphafold_impact/pipelines/data_collection_nih_funded_projects/README.md
@@ -1,0 +1,17 @@
+# NIH Funded Projects Data Collection Pipeline (`data_collection_nih_funded_projects`)
+
+## Overview
+The `data_collection_nih_funded_projects` Kedro pipeline collects NIH funded projects using the API at `https://api.reporter.nih.gov/v2/projects/search`.
+
+## Modules
+### `nodes.py`
+This module contains functions for fetching and processing NIH funded projects data which are used in the pipeline. 
+
+### `pipeline.py`
+Defines the `data_collection_nih_funded_projects` pipeline, which fetches NIH funded projects data and saves it as CSVs in a partitioned dataset on S3.
+
+## Usage
+To execute the entire `data_collection_nih_funded_projects` pipeline, run:
+```bash
+$ kedro run --pipeline data_collection_nih_funded_projects
+```

--- a/src/alphafold_impact/pipelines/data_collection_nih_funded_projects/__init__.py
+++ b/src/alphafold_impact/pipelines/data_collection_nih_funded_projects/__init__.py
@@ -1,0 +1,10 @@
+"""
+This is a boilerplate pipeline 'data_collection_nih_funded_projects'
+generated using Kedro 0.19.1
+"""
+
+from .pipeline import create_pipeline
+
+__all__ = ["create_pipeline"]
+
+__version__ = "0.1"

--- a/src/alphafold_impact/pipelines/data_collection_nih_funded_projects/nodes.py
+++ b/src/alphafold_impact/pipelines/data_collection_nih_funded_projects/nodes.py
@@ -1,0 +1,179 @@
+"""
+This module contains functions for fetching NIH funded projects data.
+
+Functions:
+    collect_nih_funded_projects: Downloads and saves NIH funded projects
+        to S3 as a partitioned dataset.
+"""
+
+import logging
+import time
+from typing import List, Dict, Tuple, Callable
+from datetime import datetime
+from calendar import monthrange
+import requests
+from requests.adapters import HTTPAdapter, Retry
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def _get_month_range(year: int, month: int) -> Tuple[str, str]:
+    """
+    Returns the first and last day of a given month in a specified year.
+
+    Args:
+        year (int): The year.
+        month (int): The month.
+
+    Returns:
+        Tuple[str, str]: A tuple containing the first and last day of the month.
+    """
+    first_day = datetime(year, month, 1)
+    _, last_day_num = monthrange(year, month)
+    last_day = datetime(year, month, last_day_num)
+    return first_day.strftime("%Y-%m-%d"), last_day.strftime("%Y-%m-%d")
+
+
+def _setup_session() -> requests.Session:
+    """Set up the requests session with retry strategy."""
+    session = requests.Session()
+    retries = Retry(
+        total=5,
+        backoff_factor=0.3,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["POST"],
+    )
+    session.mount("https://", HTTPAdapter(max_retries=retries))
+    return session
+
+
+def _get_nih_projects(
+    session: requests.Session, api_url: str, query_params: Dict[str, str]
+) -> Dict[str, str]:
+    """
+    Make an API POST request to fetch NIH projects.
+
+    Args:
+        api_url (str): API URL to use to fetch NIH funded projects.
+        session (requests.Session): The requests session.
+        query_params (dict): The query parameters for the API call.
+
+    Returns:
+        dict: The response data as a dictionary.
+    """
+    try:
+        response = session.post(api_url, json=query_params, timeout=60)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        logger.error("Request failed: %s", e)
+
+
+def _create_query_params(
+    from_date: str, to_date: str, offset: int, limit: int
+) -> Dict[str, str]:
+    """
+    Creates query parameters for NIH API requests.
+
+    Args:
+        from_date (str): Start date for the query range.
+        to_date (str): End date for the query range.
+        offset (int): The offset for pagination.
+        limit (int): Maximum number of records per API request.
+
+    Returns:
+        dict: A dictionary of query parameters.
+    """
+    return {
+        "criteria": {"award_notice_date": {"from_date": from_date, "to_date": to_date}},
+        "offset": offset,
+        "limit": limit,
+    }
+
+
+def _collect_nih_funded_projects_per_month(
+    api_url: str,
+    year: int,
+    month: int,
+    limit: int = 500,
+) -> pd.DataFrame:
+    """
+    Fetches NIH funded projects for a specified year and month.
+
+    Args:
+        api_url (str): API URL to use to fetch NIH funded projects.
+        year (int): The fiscal year for which to fetch the grants.
+        month (int): The month for which to fetch the grants.
+        limit (int): Maximum number of records per API request.
+
+    Returns:
+        pd.DataFrame: A DataFrame of funded projects for the specified year and month.
+    """
+    session = _setup_session()
+    from_date, to_date = _get_month_range(year, month)
+
+    all_projects = []
+    offset = 0
+
+    while True:
+        time.sleep(1)
+        query_params = _create_query_params(from_date, to_date, offset, limit)
+        data = _get_nih_projects(session, api_url, query_params)
+        if offset == 0:
+            total_count = data["meta"]["total"]
+        projects = data.get("results", [])
+        all_projects.extend(projects)
+        offset += len(projects)
+        if offset % 1000 == 0 or len(projects) < limit:
+            logger.info(
+                "Collected %d/%d NIH funded projects for %d-%02d",
+                offset,
+                total_count,
+                year,
+                month,
+            )
+        if len(projects) < limit:
+            break
+
+    return pd.json_normalize(all_projects)
+
+
+def _collect_nih_funded_projects_per_year(year: int, api_url: str) -> pd.DataFrame:
+    """
+    Fetches NIH funded projects for a specified year, month by month.
+
+    Args:
+        year (int): The year for which to fetch the grants.
+        api_url (str): API URL to use to fetch NIH funded projects.
+
+    Returns:
+        pd.DataFrame: A DataFrame containing all funded projects for the specified year.
+    """
+    all_projects = []
+    for month in range(1, 13):
+        monthly_projects = _collect_nih_funded_projects_per_month(api_url, year, month)
+        all_projects.append(monthly_projects)
+    return pd.concat(all_projects, ignore_index=True)
+
+
+def collect_nih_funded_projects(years: List[int], api_url: str) -> Dict[str, Callable]:
+    """
+    Generates a dictionary with keys as dataset names and values as callable
+    functions to fetch NIH funded projects for each year in the provided list.
+
+    Args:
+        years (List[int]): A list of years for which to generate the datasets.
+        api_url (str): API URL to use to fetch NIH funded projects.
+
+    Returns:
+        Dict[str, Callable]: A dictionary where each key is a dataset name for
+            a specific year, and each value is a callable that fetches the dataset
+            for that year.
+    """
+    return {
+        f"nih_funded_projects_{year}": lambda year=year: _collect_nih_funded_projects_per_year(
+            year, api_url
+        )
+        for year in years
+    }

--- a/src/alphafold_impact/pipelines/data_collection_nih_funded_projects/pipeline.py
+++ b/src/alphafold_impact/pipelines/data_collection_nih_funded_projects/pipeline.py
@@ -1,0 +1,23 @@
+"""Pipeline for data collection.
+
+This pipeline fetches NIH funded projects data.
+To run this pipeline, use the following command:
+
+    $ kedro run --pipeline data_collection_nih_funded_projects
+"""
+
+from kedro.pipeline import Pipeline, pipeline, node
+from .nodes import collect_nih_funded_projects
+
+
+def create_pipeline(**kwargs) -> Pipeline:
+    return pipeline(
+        [
+            node(
+                func=collect_nih_funded_projects,
+                inputs={"years": "params:years", "api_url": "params:api_url"},
+                outputs="raw",
+            ),
+        ],
+        namespace="nih.data_collection.funded_projects",
+    )

--- a/src/alphafold_impact/pipelines/data_collection_nih_funding_opportunities/README.md
+++ b/src/alphafold_impact/pipelines/data_collection_nih_funding_opportunities/README.md
@@ -1,0 +1,17 @@
+# NIH Funding Opportunities Data Collection Pipeline (`data_collection_nih_funding_opportunities`)
+
+## Overview
+The `data_collection_nih_funding_opportunities` Kedro pipeline collects NIH funding opportunities using the API at `https://search.grants.nih.gov/guide/api/`.
+
+## Modules
+### `nodes.py`
+This module contains functions for fetching and processing NIH funding opportunities data which are used in the pipeline. 
+
+### `pipeline.py`
+Defines the `data_collection_nih_funding_opportunities` pipeline, which fetches NIH funding opportunities data and saves it as a CSV on S3.
+
+## Usage
+To execute the entire `data_collection_nih_funding_opportunities` pipeline, run:
+```bash
+$ kedro run --pipeline data_collection_nih_funding_opportunities
+```

--- a/src/alphafold_impact/pipelines/data_collection_nih_funding_opportunities/__init__.py
+++ b/src/alphafold_impact/pipelines/data_collection_nih_funding_opportunities/__init__.py
@@ -1,0 +1,10 @@
+"""
+This is a boilerplate pipeline 'data_collection_nih_funding_opportunities'
+generated using Kedro 0.19.1
+"""
+
+from .pipeline import create_pipeline
+
+__all__ = ["create_pipeline"]
+
+__version__ = "0.1"

--- a/src/alphafold_impact/pipelines/data_collection_nih_funding_opportunities/nodes.py
+++ b/src/alphafold_impact/pipelines/data_collection_nih_funding_opportunities/nodes.py
@@ -1,0 +1,153 @@
+"""
+This module contains functions for fetching NIH funding opportunities data.
+
+Functions:
+    collect_nih_funding_opportunities: Downloads and saves NIH
+        funding opportunities to S3.
+"""
+
+import logging
+import time
+from typing import Dict, Union
+import requests
+from requests.adapters import HTTPAdapter, Retry
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def _get_params(end_date: str, perpage: int) -> Dict[str, Union[int, str]]:
+    """
+    Returns the parameters for the NIH grants API requests with
+    specified end date and records per page.
+
+    Args:
+        end_date (str): The end date for the date range filter in
+            the format 'DDMMYYYY'.
+        perpage (int): Number of records per page.
+
+    Returns:
+        Dict[str, Union[int, str]]: A dictionary of parameters for the API request.
+    """
+    return {
+        "perpage": perpage,
+        "sort": "reldate:desc",
+        "type": "active,expired,activenosis,expirednosis",
+        "parentic": "all",
+        "primaryic": "all",
+        "activitycodes": "all",
+        "doctype": "all",
+        "parentfoa": "all",
+        "daterange": f"01021991-{end_date}",
+        "clinicaltrials": "all",
+        "fields": "all",
+        "spons": "true",
+        "query": "",
+    }
+
+
+def _make_api_request(
+    url: str, params: Dict[str, Union[int, str]]
+) -> Union[Dict[str, any], None]:
+    """
+    Creates a session, makes an API request, and returns the
+    JSON response.
+
+    Args:
+        url (str): The API endpoint URL.
+        params (Dict[str, Union[int, str]]) : Parameters for the API request.
+
+    Returns:
+        Union[Dict[str, any], None]: The JSON response as a dictionary,
+            or None if the request fails.
+    """
+    session = requests.Session()
+    retries = Retry(
+        total=5, backoff_factor=0.3, status_forcelist=[429, 500, 502, 503, 504]
+    )
+    session.mount("https://", HTTPAdapter(max_retries=retries))
+
+    try:
+        response = session.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        logger.error("Request failed: %s", e)
+        return None
+
+
+def _fetch_total_results(api_url: str, end_date: str) -> int:
+    """
+    Fetches the total number of NIH grant opportunities up to a
+    specified end date.
+
+    Args:
+        api_url (str): API URL to collect NIH grant opportunities.
+        end_date (str): The end date for the date range filter in the
+            format 'DDMMYYYY'.
+
+    Returns:
+        int: Total number of results as an integer.
+    """
+    params = _get_params(end_date, 1)
+    params["from"] = 0
+
+    if json_response := _make_api_request(api_url, params):
+        return json_response["data"]["hits"]["total"]
+    logger.error("Failed to fetch total results count for end date %s", end_date)
+    return 0
+
+
+def _fetch_nih_funding_opportunities(
+    api_url: str, end_date: str, total_results: int, perpage: int = 500
+) -> pd.DataFrame:
+    """
+    Fetches all NIH grant opportunities data up to a specified end date.
+
+    Args:
+        api_url (str): API URL to collect NIH grant opportunities.
+        end_date (str): The end date for the date range filter in the
+            format 'DDMMYYYY'.
+        total_results (int): Total number of NIH grant opportunities.
+        perpage (int): Number of records per page. Defaults to 100.
+
+    Returns:
+        pd.DataFrame: A pandas DataFrame containing all NIH grant opportunities.
+    """
+    params = _get_params(end_date, perpage)
+    results = []
+    for start in range(0, total_results, perpage):
+        params["from"] = start
+        if json_response := _make_api_request(api_url, params):
+            data = pd.json_normalize(json_response["data"]["hits"]["hits"])
+            results.append(data)
+            logger.info(
+                "Collecting NIH funding opportunities from %d/%d", start, total_results
+            )
+        else:
+            logger.error("Failed to fetch data for start=%d", start)
+
+        time.sleep(1)
+
+    return pd.concat(results, ignore_index=True)
+
+
+def collect_nih_funding_opportunities(api_url: str, end_date: str) -> pd.DataFrame:
+    """
+    Fetches and processes NIH grant opportunities data up to today's date.
+
+    Args:
+        api_url (str): API URL to collect NIH grant opportunities.
+        end_date (str): Latest date to collect funding opportunities from
+            in the format ddmmyyyy.
+
+    Returns:
+        pd.DataFrame: A pandas DataFrame containing all NIH grant opportunities up
+            to today's date.
+    """
+    try:
+        total_results = _fetch_total_results(api_url, end_date)
+        return _fetch_nih_funding_opportunities(api_url, end_date, total_results)
+    except Exception as e:
+        logger.error("An error occurred: %s", e)
+        return pd.DataFrame()

--- a/src/alphafold_impact/pipelines/data_collection_nih_funding_opportunities/pipeline.py
+++ b/src/alphafold_impact/pipelines/data_collection_nih_funding_opportunities/pipeline.py
@@ -1,0 +1,23 @@
+"""Pipeline for data collection.
+
+This pipeline fetches NIH funding opportunities data.
+To run this pipeline, use the following command:
+
+    $ kedro run --pipeline data_collection_nih_funding_opportunities
+"""
+
+from kedro.pipeline import Pipeline, pipeline, node
+from .nodes import collect_nih_funding_opportunities
+
+
+def create_pipeline(**kwargs) -> Pipeline:
+    return pipeline(
+        [
+            node(
+                func=collect_nih_funding_opportunities,
+                inputs={"api_url": "params:api_url", "end_date": "params:end_date"},
+                outputs="raw",
+            ),
+        ],
+        namespace="nih.data_collection.funding_opportunities",
+    )


### PR DESCRIPTION
This PR adds:
* Pipeline to collect NIH funded projects. The projects are collected monthly to avoid hitting API limits of 15,000 records per call
* Pipeline to collect NIH funding opportunities.