### PR TITLE
[48] TCC pipelines

### DIFF
--- a/conf/base/catalog.yml
+++ b/conf/base/catalog.yml
@@ -469,7 +469,6 @@ lab.data_collection.publications.raw:
 pdb.entries.raw:
   <<: *_pq
   filepath: s3://alphafold-impact/data/01_raw/pdb/entries.parquet
-  path: s3://alphafold-impact/data/02_intermediate/oa/labs/publications/
 
 # TCC
 tcc.data_analysis:
@@ -479,3 +478,11 @@ tcc.data_analysis:
 tcc.reporting.summary_subfields:
   <<: *_csv_ptd
   path: s3://alphafold-impact/data/07_reporting/tcc/summary_subfields
+
+tcc.reporting.tcc_by_publication_quarter_subfields:
+  <<: *_image
+  filepath: s3://alphafold-impact/data/07_reporting/tcc/tcc_by_publication_quarter_subfields.png
+
+tcc.reporting.tcc_by_publication_quarter_af_levels:
+  <<: *_image
+  filepath: s3://alphafold-impact/data/07_reporting/tcc/tcc_by_publication_quarter_af_levels.png

--- a/conf/base/catalog.yml
+++ b/conf/base/catalog.yml
@@ -469,3 +469,13 @@ lab.data_collection.publications.raw:
 pdb.entries.raw:
   <<: *_pq
   filepath: s3://alphafold-impact/data/01_raw/pdb/entries.parquet
+  path: s3://alphafold-impact/data/02_intermediate/oa/labs/publications/
+
+# TCC
+tcc.data_analysis:
+  <<: *_csv_ptd
+  path: s3://alphafold-impact/data/04_analysis/tcc/
+
+tcc.reporting.summary_subfields:
+  <<: *_csv_ptd
+  path: s3://alphafold-impact/data/07_reporting/tcc/summary_subfields

--- a/conf/base/parameters.yml
+++ b/conf/base/parameters.yml
@@ -426,6 +426,19 @@ labs:
       mailto: data_analytics@nesta.org.uk
       perpage: "200"
 
+tcc:
+  "af_label": "Papers that cite AF levels 0-3"
+  "biochemistry_label": "Biochemistry"
+  "bioinformatics_label": "Bioinformatics"
+  "protein_design_label": "Protein Design"
+  "structural_biology_label": "Structural Biology"
+  partition_order:
+    - "Papers that cite AF levels 0-3"
+    - "Biochemistry"
+    - "Bioinformatics"
+    - "Protein Design"
+    - "Structural Biology"
+
 test: False
 
 true_: True

--- a/src/alphafold_impact/pipelines/data_analysis_tcc/__init__.py
+++ b/src/alphafold_impact/pipelines/data_analysis_tcc/__init__.py
@@ -1,0 +1,10 @@
+"""
+This is a boilerplate pipeline 'data_analysis_tcc'
+generated using Kedro 0.19.1
+"""
+
+from .pipeline import create_pipeline
+
+__all__ = ["create_pipeline"]
+
+__version__ = "0.1"

--- a/src/alphafold_impact/pipelines/data_analysis_tcc/nodes.py
+++ b/src/alphafold_impact/pipelines/data_analysis_tcc/nodes.py
@@ -1,0 +1,402 @@
+"""
+This module contains functions for
+calculaing time to clinical citation (TCC)
+"""
+
+import logging
+from urllib.error import HTTPError
+import time
+from typing import List, Union
+import requests
+import numpy as np
+from Bio import Entrez
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def convert_single_pubmed_id_to_int_string(
+    value: Union[str, float]
+) -> Union[str, float]:
+    """
+    Converts a value in the 'cited_by_clin' column to the correct format.
+
+    If the value is a single number (float), it's converted to an int then to a string.
+    If the value is a string with multiple numbers, it's left as is.
+    NaN values are left unchanged.
+
+    Args:
+        value (float, str, or nan): The original value in the 'cited_by_clin' column.
+
+    Returns:
+        str or nan: The converted value.
+    """
+    # Check if the value is a single float (a single PubMed ID)
+    if isinstance(value, float) and not pd.isna(value):
+        return str(int(value))
+    # Return the value unchanged if it's a string (multiple PubMed IDs) or NaN
+    return value
+
+
+def efetch_pmid(db: str, id: str, retmode: str, max_retries: int = 3, delay: int = 5):
+    """
+    Performs a Entrez efetch request to get DOI using PMID.
+
+    Args:
+        db (str): Database to query.
+        id (str): The identifier of the article.
+        retmode (str): Return mode for the request.
+        max_retries (int): Maximum number of retries.
+        delay (int): Delay between retries in seconds.
+
+    Returns:
+        HTTP response object on success, None on failure.
+    """
+    for attempt in range(max_retries):
+        try:
+            return Entrez.efetch(db=db, id=id, retmode=retmode)
+        except HTTPError as e:
+            if e.code == 502:
+                logger.info(
+                    "Attempt %d/%d for PMID %s failed with 502 Bad Gateway. Retrying in %d seconds...",
+                    attempt + 1,
+                    max_retries,
+                    id,
+                    delay,
+                )
+                time.sleep(delay)
+            else:
+                logger.error("HTTPError %d for PMID %s: %s", e.code, id, e.reason)
+                return None
+        except Exception as e:
+            logger.error("Error fetching data for PMID %s: %s", id, str(e))
+            return None
+
+    logger.info("Maximum retries reached. Unable to fetch data for PMID %s.", id)
+    return None
+
+
+def get_doi_from_pubmed(pmid: str) -> str:
+    """
+    Fetches the DOI of a PubMed article using its PMID. If unable to fetch data,
+    prints the PMID and the reason.
+
+    Args:
+        pmid (str): The PubMed ID of the article.
+
+    Returns:
+        str: The DOI of the article, or np.nan if DOI not found or an error occurs.
+    """
+    handle = efetch_pmid(db="pubmed", id=pmid, retmode="xml")
+    if handle is None:
+        return np.nan
+
+    try:
+        records = Entrez.read(handle)
+    except Exception as e:
+        logger.error("Error reading data for PMID %s: %s", pmid, str(e))
+        return np.nan
+    finally:
+        handle.close()
+
+    article = records["PubmedArticle"][0]["MedlineCitation"]["Article"]
+    if "ELocationID" in article:
+        for elocation in article["ELocationID"]:
+            if elocation.attributes.get("EIdType") == "doi":
+                return str(elocation)
+
+    logger.info("DOI not found for PMID %s.", pmid)
+    return np.nan
+
+
+def fetch_pub_date_from_openalex(doi: str) -> str:
+    """
+    Fetches the publication date from OpenAlex using the DOI of the article.
+
+    Args:
+        doi (str): The DOI of the article.
+
+    Returns:
+        str: The publication date in YYYY-MM-DD format, or np.nan.
+    """
+    try:
+        response = requests.get(f"https://api.openalex.org/works/doi:{doi}")
+        data = response.json()
+        publication_date = data.get("publication_date", None)
+        if publication_date:
+            return publication_date
+        else:
+            return np.nan
+    except Exception:
+        return np.nan
+
+
+def get_publication_date(pmid: str) -> str:
+    """
+    Fetches the publication date of an article using its PMID.
+    Tries PubMed first, then uses the DOI to fetch from OpenAlex.
+
+    Args:
+        pmid (str): The PubMed ID of the article.
+
+    Returns:
+        str: The publication date in YYYY-MM-DD format.
+    """
+    doi = get_doi_from_pubmed(pmid)
+    return fetch_pub_date_from_openalex(doi)
+
+
+def get_pub_dates_for_pmids(pmids: str) -> List[str]:
+    """
+    Fetches publication dates for a list of PubMed IDs.
+    Skips if the input is NaN or non-string.
+
+    Args:
+        pmids (str): A string containing PubMed IDs separated by spaces.
+
+    Returns:
+        List[str]: A list of publication dates in YYYY-MM-DD format or np.nan.
+                  Returns an empty list if pmids is NaN or non-string.
+    """
+    if pd.isna(pmids) or not isinstance(pmids, str):
+        return np.nan
+    return [get_publication_date(pmid) for pmid in pmids.split()]
+
+
+def find_earliest_date(dates: Union[List[str], float]) -> Union[str, float]:
+    """
+    Finds the earliest date in a list of dates.
+
+    Args:
+        dates (Union[List[str], float]): A list of date strings or nan.
+
+    Returns:
+        Union[str, float]: The earliest date in string format or nan.
+    """
+    if isinstance(dates, list):
+        dates = [date for date in dates if pd.notna(date)]
+    else:
+        return np.nan
+    if dates == []:
+        return np.nan
+    datetime_list = pd.to_datetime(dates, errors="coerce")
+    min_date = min(datetime_list)
+    return min_date.strftime("%Y-%m-%d") if pd.notna(min_date) else np.nan
+
+
+def match_oa_papers_to_icite(
+    icite_data: dict,
+    oa_data: pd.DataFrame,
+    dataset_name: str,
+) -> pd.DataFrame:
+    """
+    Find papers that are in iCite data based on both DOI and PMID.
+
+    Args:
+        icite_data (pd.DataFrame): iCite data with 'doi' and 'pmid' columns.
+        oa_data (pd.DataFrame): OpenAlex data with 'doi' and 'pmid' columns.
+        dataset_name (str): A label used for logging purposes, to denote the dataset
+            being processed.
+
+    Returns:
+        pd.DataFrame: A DataFrame containing merged information from iCite and OpenAlex datasets.
+                      It includes all columns from iCite and OpenAlex datasets.
+    """
+    oa_dois = oa_data["doi"].dropna().to_list()
+    oa_pmids = [int(pmid) for pmid in oa_data.pmid.dropna().to_list()]
+
+    logger.info("%s -- Finding matches in iCite data", dataset_name)
+
+    doi_matches = icite_data.query(f"doi in {oa_dois}")
+    pmid_matches = icite_data.query(f"pmid in {oa_pmids}")
+
+    icite_matches = (
+        pd.concat([doi_matches, pmid_matches])
+        .drop_duplicates(subset="doi")
+        .drop_duplicates(subset="pmid")
+    )
+    logger.info(
+        "%s -- %0.2f%% OA papers matched to iCite (%d / %d)",
+        dataset_name,
+        len(icite_matches) / len(oa_data) * 100,
+        len(icite_matches),
+        len(oa_data),
+    )
+    return icite_matches
+
+
+def add_clinal_citation_cols(icite_matches: pd.DataFrame) -> pd.DataFrame:
+    """
+    Modifies the provided DataFrame by converting 'cited_by_clin' values to integer strings
+    and adding publication dates for the clinical articles.
+
+    Args:
+        icite_matches (pd.DataFrame): The DataFrame to be modified.
+
+    Returns:
+        pd.DataFrame: The modified DataFrame with updated 'cited_by_clin' and
+                      'cited_by_clin_pub_dates' columns.
+    """
+    # Convert 'cited_by_clin' values to strings
+    icite_matches["cited_by_clin"] = icite_matches["cited_by_clin"].apply(
+        convert_single_pubmed_id_to_int_string
+    )
+    # Add number of clinical citations
+    icite_matches["num_cited_by_clin"] = (
+        icite_matches.cited_by_clin.str.count(" ").add(1).fillna(0, downcast="infer")
+    )
+    # Add clinical article publication dates
+    icite_matches["cited_by_clin_pub_dates"] = icite_matches["cited_by_clin"].apply(
+        get_pub_dates_for_pmids
+    )
+    # Add clinical article earliest publication date
+    icite_matches["cited_by_clin_earliest_pub_date"] = icite_matches[
+        "cited_by_clin_pub_dates"
+    ].apply(find_earliest_date)
+    icite_matches["cited_by_clin_earliest_pub_date"] = pd.to_datetime(
+        icite_matches["cited_by_clin_earliest_pub_date"]
+    )
+    return icite_matches
+
+
+def add_ctc_tcc(
+    icite_data: pd.DataFrame,
+    oa_data: pd.DataFrame,
+    dataset_name: str,
+    cutoff_date: str = "2021-07-15",
+):
+    """
+    Combines OpenAlex data with iCite data based on DOI and PMID identifiers.
+    Adds several columns related to clinical citations to the dataset,
+    such as the number of clinical citations and the days until a clinical citation.
+
+    Args:
+        icite_data (pd.DataFrame): A dictionary containing iCite data with DOI and
+            PMID keys.
+        oa_data (pd.DataFrame): A DataFrame containing OpenAlex data with
+            DOI and PMID columns.
+        dataset_name (str): A string identifier used to name the dataset.
+        cutoff_date (str): Tthe cutoff date for filtering publications.
+            Defaults to "2021-07-15".
+
+    Returns:
+        pd.DataFrame: A DataFrame containing merged iCite and OpenAlex data with additional columns:
+                      - 'num_cited_by_clin' (times cited by clinical article)
+                      - 'cited_by_clin_pub_dates' (publication dates for clinical citations)
+                      - 'cited_by_clin_earliest_pub_date' (earliest clinical citation date)
+                      - 'days_to_clinical_trial' (days from publication to earliest clinical citation)
+    """
+    oa_data_filtered = oa_data.query(f"publication_date >= '{cutoff_date}'")
+    oa_records_filtered = len(oa_data) - len(oa_data_filtered)
+    logger.info("%s -- OpenAlex papers: %d", dataset_name, len(oa_data))
+    logger.info(
+        "%s -- OpenAlex papers after %s: %d",
+        dataset_name,
+        cutoff_date,
+        len(oa_data_filtered),
+    )
+    logger.info(
+        "%s -- OpenAlex papers removed after %s: %d",
+        dataset_name,
+        cutoff_date,
+        oa_records_filtered,
+    )
+    icite_matches = match_oa_papers_to_icite(
+        icite_data=icite_data,
+        oa_data=oa_data_filtered,
+        dataset_name=dataset_name,
+    ).pipe(add_clinal_citation_cols)
+    logger.info(
+        "%s -- Number of clinical citations: %d",
+        dataset_name,
+        icite_matches.num_cited_by_clin.sum(),
+    )
+    logger.info(
+        "%s -- Number of papers with clinical citations: %d",
+        dataset_name,
+        len(icite_matches.query("cited_by_clin.notna()")),
+    )
+    icite_oa_comb = icite_matches.merge(
+        oa_data_filtered.drop_duplicates(subset="doi"),
+        how="left",
+        left_on="doi",
+        right_on="doi",
+    )
+    icite_oa_comb["publication_date"] = pd.to_datetime(
+        icite_oa_comb["publication_date"]
+    )
+    icite_oa_comb["days_to_clinical_trial"] = (
+        icite_oa_comb["cited_by_clin_earliest_pub_date"]
+        - icite_oa_comb["publication_date"]
+    ).dt.days
+
+    median_days_tcc = round(
+        icite_oa_comb.query(
+            "days_to_clinical_trial.notna()"
+        ).days_to_clinical_trial.median(),
+        1,
+    )
+    logger.info("%s -- Median days TCC: %f", dataset_name, median_days_tcc)
+    return icite_oa_comb
+
+
+def make_tcc_datasets(
+    icite_data: pd.DataFrame,
+    af_oa_data: pd.DataFrame,
+    biochemistry_oa_data: pd.DataFrame,
+    bioinformatics_oa_data: pd.DataFrame,
+    protein_design_oa_data: pd.DataFrame,
+    structural_biology_oa_data: pd.DataFrame,
+    af_label: str,
+    biochemistry_label: str,
+    bioinformatics_label: str,
+    protein_design_label: str,
+    structural_biology_label: str,
+):
+    """
+    For various subfields, combines data from iCite and OpenAlex based
+    on DOI and PMID identifiers. Calculates time to clinical citation (TCC).
+
+    Args:
+        icite_data (pd.DataFrame): iCite data with 'doi' and 'pmid' columns.
+        af_oa_data (pd.DataFrame): OpenAlex data for the papers that cite AF.
+        biochemistry_oa_data (pd.DataFrame): OpenAlex data for the field of biochemistry.
+        bioinformatics_oa_data (pd.DataFrame): OpenAlex data for the field of bioinformatics.
+        protein_design_oa_data (pd.DataFrame): OpenAlex data for the field of protein design.
+        structural_biology_oa_data (pd.DataFrame): OpenAlex data for the field of structural biology.
+        af_label (str): Label for the papers that cite AF dataset.
+        biochemistry_label (str): Label for the biochemistry dataset.
+        bioinformatics_label (str): Label for the bioinformatics dataset.
+        protein_design_label (str): Label for the protein design dataset.
+        structural_biology_label (str): Label for the structural biology dataset.
+
+    Returns:
+        dict: A dictionary mapping each dataset label to a lambda function that, when called, will
+              process and return a DataFrame containing the iCite and OpenAlex data with TCC for
+              the respective field.
+    """
+    return {
+        af_label: lambda: add_ctc_tcc(
+            icite_data=icite_data, oa_data=af_oa_data, dataset_name=af_label
+        ),
+        biochemistry_label: lambda: add_ctc_tcc(
+            icite_data=icite_data,
+            oa_data=biochemistry_oa_data,
+            dataset_name=biochemistry_label,
+        ),
+        bioinformatics_label: lambda: add_ctc_tcc(
+            icite_data=icite_data,
+            oa_data=bioinformatics_oa_data,
+            dataset_name=bioinformatics_label,
+        ),
+        protein_design_label: lambda: add_ctc_tcc(
+            icite_data=icite_data,
+            oa_data=protein_design_oa_data,
+            dataset_name=protein_design_label,
+        ),
+        structural_biology_label: lambda: add_ctc_tcc(
+            icite_data=icite_data,
+            oa_data=structural_biology_oa_data,
+            dataset_name=structural_biology_label,
+        ),
+    }

--- a/src/alphafold_impact/pipelines/data_analysis_tcc/pipeline.py
+++ b/src/alphafold_impact/pipelines/data_analysis_tcc/pipeline.py
@@ -1,0 +1,34 @@
+"""Pipeline for data anaysis.
+
+This pipeline combines OpenAlex papers with iCite/Pubmed clinical articles.
+To run this pipeline, use the following command:
+
+    $ kedro run --pipeline data_analysis_tcc
+"""
+
+from kedro.pipeline import Pipeline, pipeline, node
+from .nodes import make_tcc_datasets
+
+
+def create_pipeline(**kwargs) -> Pipeline:
+    return pipeline(
+        [
+            node(
+                func=make_tcc_datasets,
+                inputs={
+                    "icite_data": "nih.data_processing.icite.intermediate",
+                    "af_oa_data": "oa.data_processing.depth.intermediate",
+                    "biochemistry_oa_data": "oa.data_processing.subfield.biochemistry.primary",
+                    "bioinformatics_oa_data": "oa.data_processing.subfield.bioinformatics.primary",
+                    "protein_design_oa_data": "oa.data_processing.subfield.protein_design.primary",
+                    "structural_biology_oa_data": "oa.data_processing.subfield.structural_biology.primary",
+                    "af_label": "params:tcc.af_label",
+                    "biochemistry_label": "params:tcc.biochemistry_label",
+                    "bioinformatics_label": "params:tcc.bioinformatics_label",
+                    "protein_design_label": "params:tcc.protein_design_label",
+                    "structural_biology_label": "params:tcc.structural_biology_label",
+                },
+                outputs="tcc.data_analysis",
+            ),
+        ],
+    )

--- a/src/alphafold_impact/pipelines/data_processing_nih_icite/__init__.py
+++ b/src/alphafold_impact/pipelines/data_processing_nih_icite/__init__.py
@@ -1,0 +1,10 @@
+"""
+This is a boilerplate pipeline 'data_processing_nih_icite'
+generated using Kedro 0.19.1
+"""
+
+from .pipeline import create_pipeline
+
+__all__ = ["create_pipeline"]
+
+__version__ = "0.1"

--- a/src/alphafold_impact/pipelines/data_processing_nih_icite/nodes.py
+++ b/src/alphafold_impact/pipelines/data_processing_nih_icite/nodes.py
@@ -1,0 +1,53 @@
+"""This module contains functions to process iCite data.
+
+Functions:
+    - filter_and_combine_icite: Loads iCite data from a partitioned dataset,
+        filters out records before a specified year and selects only relevant columns.
+"""
+
+from typing import Dict, Callable, Any
+import logging
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def filter_and_combine_icite(
+    icite_partitions: Dict[str, Callable[[], Any]], year=2016
+) -> pd.DataFrame:
+    """Loads iCite data from a partitioned dataset, filters out
+    records before a specified year and selects only relevant columns.
+
+    Args:
+        icite_partitions (dict): iCite partitioned dataset.
+        year (int): Year to filter out records before.
+
+    Returns:
+        DataFrame of combined and filtered iCite data.
+    """
+    filtered_icite = []
+
+    for name, icite_partition in icite_partitions.items():
+        logger.info("Filtering iCite partition: %s", name)
+        icite_partition = icite_partition()
+        current_matches = icite_partition.query(f"year >= {year}")
+        logger.info("Adding %s matches", len(current_matches))
+        filtered_icite.append(current_matches)
+
+    return pd.concat(filtered_icite)[
+        [
+            "pmid",
+            "doi",
+            "title",
+            "authors",
+            "year",
+            "journal",
+            "is_research_article",
+            "citation_count",
+            "apt",
+            "is_clinical",
+            "cited_by_clin",
+            "cited_by",
+            "references",
+        ]
+    ].reset_index(drop=True)

--- a/src/alphafold_impact/pipelines/data_processing_nih_icite/pipeline.py
+++ b/src/alphafold_impact/pipelines/data_processing_nih_icite/pipeline.py
@@ -1,0 +1,21 @@
+"""This module contains the pipeline for data processing for iCite data.
+
+To run this pipeline, use the following command:
+
+    $ kedro run --pipeline data_processing_nih_icite
+"""
+
+from kedro.pipeline import Pipeline, pipeline, node
+from .nodes import filter_and_combine_icite
+
+
+def create_pipeline(**kwargs) -> Pipeline:
+    return pipeline(
+        [
+            node(
+                func=filter_and_combine_icite,
+                inputs="nih.data_collection.icite.raw",
+                outputs="nih.data_processing.icite.intermediate",
+            ),
+        ]
+    )

--- a/src/alphafold_impact/pipelines/reporting_nih_funding_opportunities/nodes.py
+++ b/src/alphafold_impact/pipelines/reporting_nih_funding_opportunities/nodes.py
@@ -1,10 +1,9 @@
 """This module contains functions to generate charts for NIH funding opportunities."""
 
-from io import BytesIO
 import pandas as pd
 import altair as alt
 from PIL import Image
-import vl_convert as vlc
+from alphafold_impact.utils.altair import altair_to_png
 
 
 def _prepare_fadirectcosts(df: pd.DataFrame) -> pd.DataFrame:
@@ -19,12 +18,6 @@ def _prepare_fadirectcosts(df: pd.DataFrame) -> pd.DataFrame:
     """
     df["fadirectcosts"] = pd.to_numeric(df["fadirectcosts"], errors="coerce")
     return df.dropna(subset=["fadirectcosts"])
-
-
-def _altair_to_png(altair_chart: alt.Chart) -> Image.Image:
-    """Convert Altair chart to PNG file"""
-    png_data = vlc.vegalite_to_png(altair_chart.to_json(), scale=2)
-    return Image.open(BytesIO(png_data))
 
 
 def plot_eb_sb_funding_opportunities(
@@ -71,7 +64,7 @@ def plot_eb_sb_funding_opportunities(
         )
         .properties(title="SB and EB NIH Funding Opportunities per Year", width=600)
     )
-    return _altair_to_png(eb_sb_funding_opportunities)
+    return altair_to_png(eb_sb_funding_opportunities)
 
 
 def plot_eb_sb_funding_opportunity_amounts(
@@ -127,7 +120,7 @@ def plot_eb_sb_funding_opportunity_amounts(
             title="SB and EB NIH Funding Opportunity Amounts per Year", width=600
         )
     )
-    return _altair_to_png(eb_sb_funding_opportunity_amounts)
+    return altair_to_png(eb_sb_funding_opportunity_amounts)
 
 
 def plot_total_funding_opportunities(
@@ -159,7 +152,7 @@ def plot_total_funding_opportunities(
         )
         .properties(title="Total NIH Funding Opportunities", width=600)
     )
-    return _altair_to_png(total_funding_opps)
+    return altair_to_png(total_funding_opps)
 
 
 def plot_total_funding_opportunity_amounts(
@@ -198,4 +191,4 @@ def plot_total_funding_opportunity_amounts(
         )
         .properties(title="Total NIH Funding Opportunity Amounts", width=600)
     )
-    return _altair_to_png(total_funding_opp_amounts_per_year)
+    return altair_to_png(total_funding_opp_amounts_per_year)

--- a/src/alphafold_impact/pipelines/reporting_tcc/__init__.py
+++ b/src/alphafold_impact/pipelines/reporting_tcc/__init__.py
@@ -1,0 +1,10 @@
+"""
+This is a boilerplate pipeline 'reporting_tcc'
+generated using Kedro 0.19.1
+"""
+
+from .pipeline import create_pipeline
+
+__all__ = ["create_pipeline"]
+
+__version__ = "0.1"

--- a/src/alphafold_impact/pipelines/reporting_tcc/nodes.py
+++ b/src/alphafold_impact/pipelines/reporting_tcc/nodes.py
@@ -1,12 +1,11 @@
 """This module contains functions to generate charts and
 summary tables for time to clinical citation."""
 
-from io import BytesIO
+from typing import List, Dict, Callable, Any
 import pandas as pd
 import altair as alt
 from PIL import Image
-import vl_convert as vlc
-from typing import List, Dict, Callable, Any
+from alphafold_impact.utils.altair import altair_to_png
 
 
 def create_tcc_summary_subfields(
@@ -23,8 +22,8 @@ def create_tcc_summary_subfields(
         oa_datasets (List[pd.DataFrame]): A list of OpenAlex papers DataFrames.
         tcc_datasets (List[pd.DataFrame]): A list of Pubmed/OpenAlex matches with TCC data.
         subfield_names (List[str]): A list of subfield names corresponding to the datasets.
-        mode (str): 'exclude' excludes papers that cite AF, 'include' includes papers that cite AF,
-            'only' uses only the papers that cite AF.
+        mode (str): For the subfield data 'exclude' excludes papers that cite AF,
+            'include' includes papers that cite AF, 'only' uses only the papers that cite AF.
 
     Returns:
         pd.DataFrame: A summary TCC DataFrame.
@@ -80,7 +79,7 @@ def create_tcc_summary_af_levels(
 ) -> pd.DataFrame:
     """
     Create a time to clinical citation (TCC) summary DataFrame for
-    the papers that cite AlphaFold by level.
+    the papers that cite AlphaFold by citation 'level'.
 
     Args:
         af_oa_data (pd.DataFrame): Papers in OpenAlex that cite AF (levels 0-3).
@@ -89,27 +88,19 @@ def create_tcc_summary_af_levels(
     Returns:
         pd.DataFrame: A summary TCC DataFrame for the papers that cite AlphaFold by level.
     """
-    af_oa_data_lvl0 = af_oa_data.query("level == 0")
-    af_oa_data_lvl1 = af_oa_data.query("level == 1")
-    af_oa_data_lvl2 = af_oa_data.query("level == 2")
-    af_oa_data_lvl3 = af_oa_data.query("level == 3")
     oa_datasets = [
         af_oa_data,
-        af_oa_data_lvl0,
-        af_oa_data_lvl1,
-        af_oa_data_lvl2,
-        af_oa_data_lvl3,
+        af_oa_data.query("level == 0"),
+        af_oa_data.query("level == 1"),
+        af_oa_data.query("level == 2"),
+        af_oa_data.query("level == 3"),
     ]
-    af_tcc_data_lvl0 = af_tcc_data.query("level == 0")
-    af_tcc_data_lvl1 = af_tcc_data.query("level == 1")
-    af_tcc_data_lvl2 = af_tcc_data.query("level == 2")
-    af_tcc_data_lvl3 = af_tcc_data.query("level == 3")
     tcc_datasets = [
         af_tcc_data,
-        af_tcc_data_lvl0,
-        af_tcc_data_lvl1,
-        af_tcc_data_lvl2,
-        af_tcc_data_lvl3,
+        af_tcc_data.query("level == 0"),
+        af_tcc_data.query("level == 1"),
+        af_tcc_data.query("level == 2"),
+        af_tcc_data.query("level == 3"),
     ]
     level_names = [
         "Papers that cite AF (levels 0-3)",
@@ -161,10 +152,28 @@ def reorder_dict_by_keys(
 
 
 def save_tcc_summary_subfields(
-    tcc_subfield_partitions: Dict[str, Callable[[], Any]],
-    oa_datasets: list,
+    tcc_subfield_partitions: Dict[str, Callable[[], pd.DataFrame]],
+    oa_datasets: List[pd.DataFrame],
     partition_order: list,
-) -> Dict[str, Callable[[], Any]]:
+) -> Dict[str, Callable[[], pd.DataFrame]]:
+    """
+    Returns a dictionary of callable functions designed to generate summary TCC DataFrames.
+
+    Args:
+        tcc_subfield_partitions (Dict[str, Callable[[], pd.DataFrame]]): A dictionary where
+            each key is a string representing a subfield, and each value is a callable that returns
+            a DataFrame containing data for that subfield.
+        oa_datasets (List[pd.DataFrame]): A list of DataFrames containing OpenAlex data
+            for various subfields.
+        partition_order (List[str]): A list of strings that define the new order of keys
+            for organizing the 'tcc_subfield_partitions' dictionary. This controls the order
+            in which summaries are generated and processed.
+
+    Returns:
+        Dict[str, Callable[[], pd.DataFrame]]: A dictionary where each key is a string
+            describing the summary table (e.g., 'tcc_summary_subfields_include_af') and
+            each value is a callable that generates the corresponding summary DataFrame.
+    """
     tcc_subfield_partitions = reorder_dict_by_keys(
         tcc_subfield_partitions, partition_order
     )
@@ -189,3 +198,141 @@ def save_tcc_summary_subfields(
             oa_datasets[0], tcc_datasets[0]
         ),
     }
+
+
+def plot_tcc_each_quarter_subfields(
+    tcc_subfield_partitions: Dict[str, Callable[[], pd.DataFrame]],
+    mode: str = "exclude",
+    max_quarter: str = "2023Q4",
+) -> Image.Image:
+    """
+    Plots the median days to clinical citation against quarterly publication date,
+    with lines colored by the 'subfield' column.
+
+    Args:
+        tcc_subfield_partitions (Dict[str, Callable[[], Any]]): TCC data for papers
+            that cite AF and subfields.
+        mode (str): 'exclude' excludes papers that cite AF from the subfield data,
+            any other input includes the papers that cite Af.
+        max_quarter (str): Last quarter to plot. Defaults to '2023Q4'.
+
+    Returns:
+        Image.Image: PNG chart.
+    """
+    af_tcc_data = (
+        tcc_subfield_partitions["Papers that cite AF levels 0-3"]()
+        .assign(subfield="Papers that cite AF levels 0-3")
+        .dropna(subset="doi")
+    )
+    af_dois = af_tcc_data.doi.to_list()
+
+    combined_data = [af_tcc_data]
+    tcc_subfield_partitions.pop("Papers that cite AF levels 0-3")
+
+    for subfield_name, tcc_dataset in tcc_subfield_partitions.items():
+        tcc_dataset = tcc_dataset()
+        if mode == "exclude":
+            tcc_dataset = tcc_dataset.query(f"doi not in {af_dois}")
+        combined_data.append(tcc_dataset.assign(subfield=subfield_name))
+
+    combined_data = pd.concat(combined_data).query("days_to_clinical_trial.notna()")
+
+    combined_data["publication_date"] = pd.to_datetime(
+        combined_data["publication_date"]
+    )
+    combined_data["quarter"] = combined_data["publication_date"].dt.to_period("Q")
+    max_quarter = pd.Period(max_quarter, freq="Q")
+    combined_data = combined_data[combined_data["quarter"] <= max_quarter]
+
+    grouped_df = (
+        combined_data.groupby(["quarter", "subfield"])
+        .agg(median_days_to_clinical_trial=("days_to_clinical_trial", "median"))
+        .reset_index()
+    )
+
+    # Convert 'quarter' back to string for plotting purposes
+    grouped_df["quarter"] = grouped_df["quarter"].astype(str)
+
+    chart = (
+        alt.Chart(grouped_df)
+        .mark_line()
+        .encode(
+            x=alt.X(
+                "quarter:O", title="Publication quarter", axis=alt.Axis(labelAngle=0)
+            ),
+            y=alt.Y(
+                "median_days_to_clinical_trial:Q",
+                title="Median days to clinical citation",
+                scale=alt.Scale(zero=True),
+            ),
+            color=alt.Color(
+                "subfield:N",
+                title="Subfield",
+                legend=alt.Legend(orient="top-right", offset=10),
+            ),
+        )
+        .properties(
+            title="Median days to clinical citation by publication quarter",
+            width=800,
+            height=400,
+        )
+    )
+    return altair_to_png(chart)
+
+
+def plot_tcc_each_quarter_af_levels(
+    tcc_subfield_partitions: Dict[str, Callable[[], pd.DataFrame]]
+) -> alt.Chart:
+    """
+    Plots the median days to clinical citation against quarterly publication date, with lines
+    colored by the citation 'level' column.
+
+    Args:
+        tcc_subfield_partitions (Dict[str, Callable[[], Any]]): TCC data for papers that cite AF and subfields.
+
+    Returns:
+        Image.Image: PNG chart.
+    """
+    af_tcc_data = (
+        tcc_subfield_partitions["Papers that cite AF levels 0-3"]()
+        .query("level.notna()")
+        .query("days_to_clinical_trial.notna()")
+    )
+    af_tcc_data["publication_date"] = pd.to_datetime(af_tcc_data["publication_date"])
+    af_tcc_data["quarter"] = af_tcc_data["publication_date"].dt.to_period("Q")
+    max_quarter = pd.Period("2023Q4", freq="Q")
+    af_tcc_data = af_tcc_data[af_tcc_data["quarter"] <= max_quarter]
+    grouped_df = (
+        af_tcc_data.groupby(["quarter", "level"])
+        .agg(median_days_to_clinical_trial=("days_to_clinical_trial", "median"))
+        .reset_index()
+    )
+
+    # Convert 'quarter' back to string for plotting purposes
+    grouped_df["quarter"] = grouped_df["quarter"].astype(str)
+
+    chart = (
+        alt.Chart(grouped_df)
+        .mark_line()
+        .encode(
+            x=alt.X(
+                "quarter:O", title="Publication quarter", axis=alt.Axis(labelAngle=0)
+            ),
+            y=alt.Y(
+                "median_days_to_clinical_trial:Q",
+                title="Median days to clinical citation",
+            ),
+            color=alt.Color(
+                "level:N",
+                title="Level",
+                legend=alt.Legend(orient="top-right", offset=10),
+            ),
+        )
+        .properties(
+            title="Median days to clinical citation by publication quarter",
+            width=800,
+            height=400,
+        )
+    )
+
+    return altair_to_png(chart)

--- a/src/alphafold_impact/pipelines/reporting_tcc/nodes.py
+++ b/src/alphafold_impact/pipelines/reporting_tcc/nodes.py
@@ -1,0 +1,191 @@
+"""This module contains functions to generate charts and
+summary tables for time to clinical citation."""
+
+from io import BytesIO
+import pandas as pd
+import altair as alt
+from PIL import Image
+import vl_convert as vlc
+from typing import List, Dict, Callable, Any
+
+
+def create_tcc_summary_subfields(
+    oa_datasets: List[pd.DataFrame],
+    tcc_datasets: List[pd.DataFrame],
+    subfield_names: List[str],
+    mode: str,
+) -> pd.DataFrame:
+    """
+    Create a time to clinical citation (TCC) summary DataFrame.
+    Papers that cite AF should be in 0th position in the lists.
+
+    Args:
+        oa_datasets (List[pd.DataFrame]): A list of OpenAlex papers DataFrames.
+        tcc_datasets (List[pd.DataFrame]): A list of Pubmed/OpenAlex matches with TCC data.
+        subfield_names (List[str]): A list of subfield names corresponding to the datasets.
+        mode (str): 'exclude' excludes papers that cite AF, 'include' includes papers that cite AF,
+            'only' uses only the papers that cite AF.
+
+    Returns:
+        pd.DataFrame: A summary TCC DataFrame.
+    """
+    af_oa_df = oa_datasets[0]
+    af_tcc_df = tcc_datasets[0]
+    af_dois = af_oa_df.doi.to_list()
+    if mode == "exclude":
+        oa_datasets = [af_oa_df] + [
+            oa_dataset.query(f"doi not in {af_dois}") for oa_dataset in oa_datasets[1:]
+        ]
+        tcc_datasets = [af_tcc_df] + [
+            tcc_dataset.query(f"doi not in {af_dois}")
+            for tcc_dataset in tcc_datasets[1:]
+        ]
+    elif mode == "only":
+        oa_datasets = [af_oa_df] + [
+            oa_dataset.query(f"doi in {af_dois}") for oa_dataset in oa_datasets[1:]
+        ]
+        tcc_datasets = [af_tcc_df] + [
+            tcc_dataset.query(f"doi in {af_dois}") for tcc_dataset in tcc_datasets[1:]
+        ]
+
+    summary_data = []
+
+    for subfield, oa_df, tcc_df in zip(subfield_names, oa_datasets, tcc_datasets):
+        oa_df_filtered = oa_df.query("publication_date >= '2021-07-15'")
+        oa_papers = len(oa_df_filtered)
+        pubmed_papers = len(tcc_df)
+        clinical_citations = tcc_df["num_cited_by_clin"].sum()
+        cc_per_pubmed_paper = clinical_citations / pubmed_papers
+        median_days_tcc = tcc_df.query("days_to_clinical_trial.notna()")[
+            "days_to_clinical_trial"
+        ].median()
+
+        summary_data.append(
+            {
+                "Subfield": subfield,
+                "OA Papers": oa_papers,
+                "Pubmed Papers": pubmed_papers,
+                "Clinical Citations": clinical_citations,
+                "Clinical Citations per Pubmed Paper": cc_per_pubmed_paper,
+                "Median Days TCC": median_days_tcc,
+            }
+        )
+
+    return pd.DataFrame(summary_data)
+
+
+def create_tcc_summary_af_levels(
+    af_oa_data: pd.DataFrame,
+    af_tcc_data: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Create a time to clinical citation (TCC) summary DataFrame for
+    the papers that cite AlphaFold by level.
+
+    Args:
+        af_oa_data (pd.DataFrame): Papers in OpenAlex that cite AF (levels 0-3).
+        af_tcc_data (pd.DataFrame): Pubmed/OpenAlex matches for papers that cite AF with TCC data.
+
+    Returns:
+        pd.DataFrame: A summary TCC DataFrame for the papers that cite AlphaFold by level.
+    """
+    af_oa_data_lvl0 = af_oa_data.query("level == 0")
+    af_oa_data_lvl1 = af_oa_data.query("level == 1")
+    af_oa_data_lvl2 = af_oa_data.query("level == 2")
+    af_oa_data_lvl3 = af_oa_data.query("level == 3")
+    oa_datasets = [
+        af_oa_data,
+        af_oa_data_lvl0,
+        af_oa_data_lvl1,
+        af_oa_data_lvl2,
+        af_oa_data_lvl3,
+    ]
+    af_tcc_data_lvl0 = af_tcc_data.query("level == 0")
+    af_tcc_data_lvl1 = af_tcc_data.query("level == 1")
+    af_tcc_data_lvl2 = af_tcc_data.query("level == 2")
+    af_tcc_data_lvl3 = af_tcc_data.query("level == 3")
+    tcc_datasets = [
+        af_tcc_data,
+        af_tcc_data_lvl0,
+        af_tcc_data_lvl1,
+        af_tcc_data_lvl2,
+        af_tcc_data_lvl3,
+    ]
+    level_names = [
+        "Papers that cite AF (levels 0-3)",
+        "Papers that cite AF (level 0)",
+        "Papers that cite AF (level 1)",
+        "Papers that cite AF (level 2)",
+        "Papers that cite AF (level 3)",
+    ]
+    summary_data = []
+
+    for subfield, oa_df, tcc_df in zip(level_names, oa_datasets, tcc_datasets):
+        oa_df_filtered = oa_df.query("publication_date >= '2021-07-15'")
+        oa_papers = len(oa_df_filtered)
+        pubmed_papers = len(tcc_df)
+        clinical_citations = tcc_df["num_cited_by_clin"].sum()
+        cc_per_pubmed_paper = clinical_citations / pubmed_papers
+        median_days_tcc = tcc_df.query("days_to_clinical_trial.notna()")[
+            "days_to_clinical_trial"
+        ].median()
+
+        summary_data.append(
+            {
+                "Subfield": subfield,
+                "OA Papers": oa_papers,
+                "Pubmed Papers": pubmed_papers,
+                "Clinical Citations": clinical_citations,
+                "Clinical Citations per Pubmed Paper": cc_per_pubmed_paper,
+                "Median Days TCC": median_days_tcc,
+            }
+        )
+
+    return pd.DataFrame(summary_data)
+
+
+def reorder_dict_by_keys(
+    original_dict: Dict[Any, Any], key_order: List[Any]
+) -> Dict[Any, Any]:
+    """
+    Reorders a dictionary based on a given list of keys.
+
+    Args:
+        original_dict (Dict[Any, Any]): The original dictionary to reorder.
+        key_order (List[Any]): The list of keys defining the new order.
+
+    Returns:
+        Dict[Any, Any]: A new dictionary reordered according to `key_order`.
+    """
+    return {key: original_dict[key] for key in key_order if key in original_dict}
+
+
+def save_tcc_summary_subfields(
+    tcc_subfield_partitions: Dict[str, Callable[[], Any]],
+    oa_datasets: list,
+    partition_order: list,
+) -> Dict[str, Callable[[], Any]]:
+    tcc_subfield_partitions = reorder_dict_by_keys(
+        tcc_subfield_partitions, partition_order
+    )
+    tcc_datasets = []
+    subfield_names = []
+    for subfield_name, tcc_dataset in tcc_subfield_partitions.items():
+        tcc_dataset = tcc_dataset()
+        tcc_datasets.append(tcc_dataset)
+        subfield_names.append(subfield_name)
+
+    return {
+        "tcc_summary_subfields_include_af": lambda: create_tcc_summary_subfields(
+            oa_datasets, tcc_datasets, subfield_names, mode="include"
+        ),
+        "tcc_summary_subfields_exclude_af": lambda: create_tcc_summary_subfields(
+            oa_datasets, tcc_datasets, subfield_names, mode="exclude"
+        ),
+        "tcc_summary_subfields_only_af": lambda: create_tcc_summary_subfields(
+            oa_datasets, tcc_datasets, subfield_names, mode="only"
+        ),
+        "tcc_summary_af_levels": lambda: create_tcc_summary_af_levels(
+            oa_datasets[0], tcc_datasets[0]
+        ),
+    }

--- a/src/alphafold_impact/pipelines/reporting_tcc/pipeline.py
+++ b/src/alphafold_impact/pipelines/reporting_tcc/pipeline.py
@@ -1,0 +1,42 @@
+"""Pipeline for reporting.
+
+This pipeline produces TCC charts and tables.
+To run this pipeline, use the following command:
+
+    $ kedro run --pipeline reporting_tcc
+"""
+
+from kedro.pipeline import Pipeline, pipeline, node
+from .nodes import save_tcc_summary_subfields
+
+
+def aggregate_datasets(*datasets):
+    """Aggregates multiple datasets into a list."""
+    return list(datasets)
+
+
+def create_pipeline(**kwargs) -> Pipeline:
+    return Pipeline(
+        [
+            node(
+                func=aggregate_datasets,
+                inputs=[
+                    "oa.data_processing.depth.intermediate",
+                    "oa.data_processing.subfield.biochemistry.primary",
+                    "oa.data_processing.subfield.bioinformatics.primary",
+                    "oa.data_processing.subfield.protein_design.primary",
+                    "oa.data_processing.subfield.structural_biology.primary",
+                ],
+                outputs="aggregated_oa_datasets",
+            ),
+            node(
+                func=save_tcc_summary_subfields,
+                inputs={
+                    "tcc_subfield_partitions": "tcc.data_analysis",
+                    "oa_datasets": "aggregated_oa_datasets",
+                    "partition_order": "params:tcc.partition_order",
+                },
+                outputs="tcc.reporting.summary_subfields",
+            ),
+        ],
+    )

--- a/src/alphafold_impact/pipelines/reporting_tcc/pipeline.py
+++ b/src/alphafold_impact/pipelines/reporting_tcc/pipeline.py
@@ -7,7 +7,11 @@ To run this pipeline, use the following command:
 """
 
 from kedro.pipeline import Pipeline, pipeline, node
-from .nodes import save_tcc_summary_subfields
+from .nodes import (
+    save_tcc_summary_subfields,
+    plot_tcc_each_quarter_subfields,
+    plot_tcc_each_quarter_af_levels,
+)
 
 
 def aggregate_datasets(*datasets):
@@ -37,6 +41,20 @@ def create_pipeline(**kwargs) -> Pipeline:
                     "partition_order": "params:tcc.partition_order",
                 },
                 outputs="tcc.reporting.summary_subfields",
+            ),
+            node(
+                func=plot_tcc_each_quarter_subfields,
+                inputs={
+                    "tcc_subfield_partitions": "tcc.data_analysis",
+                },
+                outputs="tcc.reporting.tcc_by_publication_quarter_subfields",
+            ),
+            node(
+                func=plot_tcc_each_quarter_af_levels,
+                inputs={
+                    "tcc_subfield_partitions": "tcc.data_analysis",
+                },
+                outputs="tcc.reporting.tcc_by_publication_quarter_af_levels",
             ),
         ],
     )

--- a/src/alphafold_impact/utils/altair.py
+++ b/src/alphafold_impact/utils/altair.py
@@ -1,0 +1,12 @@
+"""Altair utils"""
+
+from io import BytesIO
+import vl_convert as vlc
+from PIL import Image
+import altair as alt
+
+
+def altair_to_png(altair_chart: alt.Chart) -> Image.Image:
+    """Convert Altair chart to PNG file"""
+    png_data = vlc.vegalite_to_png(altair_chart.to_json(), scale=2)
+    return Image.open(BytesIO(png_data))


### PR DESCRIPTION
This PR adds the following pipelines:
- `data_processing_nih_icite` which combines iCite partitions into one file
- `data_analysis_tcc` which joins OpenAlex papers to Pubmed and then calculates TCC
- `reporting_tcc` which creates TCC summary tables and TCC charts